### PR TITLE
requiring engine-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In the meantime, you can install it like any other elisp file by adding
 it to your load path and globally enabling it:
 
 ```emacs
-(require 'engine)
+(require 'engine-mode)
 (engine-mode t)
 ```
 


### PR DESCRIPTION
`(require 'engine)` tells me `Cannot open load file: engine`. `(require 'engine-mode)` works just fine. Thanks for this great mode!
