### PR TITLE
Add keymap to engine-mode docstring

### DIFF
--- a/engine-mode.el
+++ b/engine-mode.el
@@ -51,7 +51,9 @@
 (eval-when-compile (require 'cl))
 
 (define-minor-mode engine-mode
-  "Minor mode for defining and querying search engines through Emacs."
+  "Minor mode for defining and querying search engines through Emacs.
+
+\\{engine-mode-map}"
   :global t
   :keymap (make-sparse-keymap))
 


### PR DESCRIPTION
`\\{engine-mode-map}` will display an automatically generated list of *current* keybindings with clickable links to the bound functions whenever the docstring is viewed in a help buffer ( <kbd>C-h f</kbd> `engine-mode`, <kbd>C-h m</kbd>, etc. ).

This may address what @rocky is after in #7 in a way that is integrated with the Emacs help system.