### PR TITLE
Added support for recoding the search-term.

### DIFF
--- a/engine-mode.el
+++ b/engine-mode.el
@@ -97,7 +97,7 @@
     `(define-key engine-mode-map (kbd ,(engine/scope-keybinding keybinding))
        (quote ,(engine/function-name engine-name)))))
 
-(defmacro defengine (engine-name search-engine-url &optional keybinding)
+(defmacro defengine (engine-name search-engine-url &optional keybinding &rest args)
   "Define a custom search engine.
 
 `engine-name' is a symbol naming the engine.
@@ -124,7 +124,10 @@ Hitting \"C-c / w\" will be bound to the newly-defined
        ,(engine/docstring engine-name)
        (interactive
         (list (engine/get-query ,(symbol-name engine-name))))
-       (engine/execute-search ,search-engine-url search-term))
+       (engine/execute-search ,search-engine-url
+                              ,(if (plist-get args ':coding)
+                                   `(encode-coding-string search-term ',(plist-get args ':coding))
+                                 'search-term)))
      ,(engine/bind-key engine-name keybinding)))
 
 (provide 'engine-mode)


### PR DESCRIPTION
See https://github.com/hrs/engine-mode/issues/10

Proof of concept. Adds `:coding` as a (kind of) named argument to `defengine`:

```lisp
(defengine diec2
  "dlc.iec.cat/results.asp?txtEntrada=%s"
  "c"
  :coding latin-1)
```
Problem: at this point `keybinding` becomes required, otherwise it will *steal* one value from `args`. My preferred solution would be adding a `:key` argument and removing `keybinding`. A backward compatible solution could be something on the line of:

```lisp
(when (oddp (length args))
  (setq args (cons keybinding args))
  (setq keybinding nil))
```
or just especify `nil` as the key.

I would like to gather some opinions before continuing.