### PR TITLE
Allow defengine to assign custom docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ engines. `defengine` uses the prefix internally, so if you change the
 prefix after defining your engines you'll find that they still use the
 old prefix.
 
+## Custom docstrings
+
+`defengine` assigns each engine a reasonable default docstring, but
+you can override that on a case-by-case basis with the `:docstring`
+keyword argument:
+
+```emacs
+(defengine ctan
+  "http://www.ctan.org/search/?x=1&PORTAL=on&phrase=%s"
+  :docstring "Search the Comprehensive TeX Archive Network (ctan.org)")
+```
+
 ## Importing keyword searches from other browsers
 
 Since many browsers save keyword searches using the same format as
@@ -106,7 +118,8 @@ the `:keybinding` keyword to the generated engine definitions).
   "http://www.google.com/images?hl=en&source=hp&biw=1440&bih=795&gbv=2&aq=f&aqi=&aql=&oq=&q=%s")
 
 (defengine google-maps
-  "http://maps.google.com/maps?q=%s")
+  "http://maps.google.com/maps?q=%s"
+  :docstring "Mappin' it up.")
 
 (defengine project-gutenberg
   "http://www.gutenberg.org/ebooks/search.html/?format=html&default_prefix=all&sort_order=&query=%s")
@@ -122,7 +135,8 @@ the `:keybinding` keyword to the generated engine definitions).
 
 (defengine wikipedia
   "http://www.wikipedia.org/search-redirect.php?language=en&go=Go&search=%s"
-  :keybinding "w")
+  :keybinding "w"
+  :docstring "Searchin' the wikis.")
 
 (defengine wiktionary
   "https://www.wikipedia.org/search-redirect.php?family=wiktionary&language=en&go=Go&search=%s")

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -97,14 +97,17 @@
     `(define-key engine-mode-map (kbd ,(engine/scope-keybinding keybinding))
        (quote ,(engine/function-name engine-name)))))
 
-(cl-defmacro defengine (engine-name search-engine-url &key keybinding)
+(cl-defmacro defengine (engine-name search-engine-url &key keybinding docstring)
   "Define a custom search engine.
 
 `engine-name' is a symbol naming the engine.
 `search-engine-url' is the url to be queried, with a \"%s\"
 standing in for the search term.
-The keyword argument `keybinding' is a string describing the key
-to bind the new function.
+The optional keyword argument `keybinding' is a string describing
+the key to bind the new function.
+The optional keyword argument `docstring' assigns a docstring to
+the generated function. A reasonably sensible docstring will be
+generated if a custom one isn't provided.
 
 Keybindings are prefixed by the `engine/keymap-prefix', which
 defaults to `C-c /'.
@@ -113,7 +116,8 @@ For example, to search Wikipedia, use:
 
   (defengine wikipedia
     \"http://www.wikipedia.org/search-redirect.php?language=en&go=Go&search=%s\"
-    :keybinding \"w\")
+    :keybinding \"w\"
+    :docstring \"Search Wikipedia!\")
 
 Hitting \"C-c / w\" will be bound to the newly-defined
 `engine/search-wikipedia' function."
@@ -121,7 +125,7 @@ Hitting \"C-c / w\" will be bound to the newly-defined
   (assert (symbolp engine-name))
   `(prog1
      (defun ,(engine/function-name engine-name) (search-term)
-       ,(engine/docstring engine-name)
+       ,(or docstring (engine/docstring engine-name))
        (interactive
         (list (engine/get-query ,(symbol-name engine-name))))
        (engine/execute-search ,search-engine-url search-term))


### PR DESCRIPTION
When `defengine` creates a search function it assigns it a generic automatically-generated docstring. This looks like:

`"Search [engine-name] for the selected text. Prompt for input if none is provided."`

That's fine, but sometimes we want to be able to assign our own custom docstrings. This commit provides an "docstring" keyword argument to `defengine`, which we can use as follows:

```emacs
(defengine ctan
  "http://www.ctan.org/search/?x=1&PORTAL=on&phrase=%s"
  :keybinding "c"
  :docstring "Search the Comprehensive TeX Archive Network (ctan.org)")
```

Thanks to @clemso for the suggestion and preliminary implementation!