### PR TITLE
Add a custom variable to set the default browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,20 @@ load path and globally enabling it:
 
 ## Changing your default browser
 
-`engine-mode` uses `browse-url` to open the URL it constructs. To
-change the browser that `browse-url` uses, you'll need to redefine
-the `browse-url-browser-function` variable.
-
-For example, to use Emacs' built-in `eww` browser:
+`engine-mode` uses the `engine/browser-function` variable to determine
+which browser it should use to open the URL it constructs. To change
+the default browser, redefine `engine/browser-function`. For example,
+to always use Emacs' built-in `eww` browser:
 
 ```emacs
-(setq browse-url-browser-function 'eww-browse-url)
+(setq engine/browser-function 'eww-browse-url)
 ```
 
+`engine/browser-function` defaults to `browse-url-browser-function`,
+which Emacs uses globally to open links.
+
 The implementation of the `browse-url-browser-function` variable
-contains a comprehensive list of possible browsing functions. You can
+contains a comprehensive list of possible browser functions. You can
 get to that by hitting `C-h v browser-url-browser-function <RETURN>`
 and following the link to `browse-url.el`.
 

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -1,7 +1,7 @@
 ;;; engine-mode.el --- Define and query search engines from within Emacs.
 
 ;; Author: Harry R. Schwartz <hello@harryrschwartz.com>
-;; Version: 2015.05.17
+;; Version: 2015.05.19
 ;; URL: https://github.com/hrs/engine-mode/engine-mode.el
 
 ;; This file is NOT part of GNU Emacs.
@@ -62,6 +62,12 @@
   :group 'engine-mode
   :type 'string)
 
+(defcustom engine/browser-function browse-url-browser-function
+  "The default browser function used when opening a URL in an engine.
+Defaults to `browse-url-browser-function'."
+  :group 'engine-mode
+  :type 'symbol)
+
 (defun engine/search-prompt (engine-name)
   (concat "Search " (capitalize engine-name) ": "))
 
@@ -98,7 +104,7 @@
     `(define-key engine-mode-map (kbd ,(engine/scope-keybinding keybinding))
        (quote ,(engine/function-name engine-name)))))
 
-(cl-defmacro defengine (engine-name search-engine-url &key keybinding docstring (browser 'browse-url-browser-function) (term-transformation-hook 'identity))
+(cl-defmacro defengine (engine-name search-engine-url &key keybinding docstring (browser 'engine/browser-function) (term-transformation-hook 'identity))
   "Define a custom search engine.
 
 `engine-name' is a symbol naming the engine.


### PR DESCRIPTION
Previously, if a user wanted to change the default browser for all engines, they had to overwrite `browse-url-browser-function`. That's not great, since Emacs uses that globally to open *all* links.

Now, to set the default browser for engine-mode only, users can overwrite the `engine/browser-function` variable instead. `engine/browser-function` defaults to `browse-url-browser-function`, so there shouldn't be any compatibility issues.

Thanks very much to @asok for the idea and initial implementation!