### PR TITLE
Nest prefixed keymaps correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,12 @@ As mentioned about, see the implementation of the
 ## Changing the keymap prefix
 
 The default keymap prefix for `engine-mode` is `C-c /`. If you'd like
-to use a different prefix (say, `C-c s`), you can redefine it:
+to bind the keymap to an additional prefix (say, `C-c s`), you totally
+can:
 
 ```emacs
-(setq engine/keymap-prefix (kbd "C-c s"))
+(engine/set-keymap-prefix (kbd "C-c s"))
 ```
-
-Make sure you redefine the keymap prefix *before* you define your
-engines. `defengine` uses the prefix internally, so if you change the
-prefix after defining your engines you'll find that they still use the
-old prefix.
 
 ## Custom docstrings
 


### PR DESCRIPTION
We'd been handling prefixes by defining a string `engine/keymap-prefix` which contained the prefix, concatenating that with the `:keybinding` when an engine was defined, and then binding the engine to that resulting string. That's not great:

* Sometimes perfectly valid prefix keys aren't represented as strings (e.g. `(kbd "s-/")`), so concatenation fails.
* Engines can't be automatically rebound to a new prefix once they've been defined.
* Keymaps are just cleaner and easier to handle.

Instead, we're defining a proper keymap and doing away with `engine/keymap-prefix`. This isn't great for backwards compatibility, since folks may have been relying on setting that to get the correct keymap. Sorry about that. =/

Now users will need to use `engine/set-prefix-key`, which binds the keymap. This has the advantage of being a function, instead of just a variable, so we should be able to modify it in the future without disturbing the interface.