### PR TITLE
Fix rebind key conflict.

### DIFF
--- a/engine-mode.el
+++ b/engine-mode.el
@@ -65,6 +65,7 @@
 For example, to use \"C-c s\" instead of the default \"C-x /\":
 
 (engine/set-keymap-prefix (kbd \"C-c s\"))"
+  (define-key engine-mode-map (kbd engine/keybinding-prefix) nil)
   (define-key engine-mode-map prefix-key engine-mode-prefixed-map))
 
 (defcustom engine/keybinding-prefix "C-x /"


### PR DESCRIPTION
Fix #32 and #12, clear `engine/keybinding-prefix` before define new prefix key.