### PR TITLE
Improve autoloading and reduce loading side-effects

### DIFF
--- a/engine-mode.el
+++ b/engine-mode.el
@@ -51,7 +51,8 @@
 (eval-when-compile (require 'cl))
 
 (defvar engine-mode-map (make-sparse-keymap))
-(defvar engine-mode-prefixed-map (make-sparse-keymap))
+(define-prefix-command 'engine-mode-prefixed-map)
+(defvar engine-mode-prefixed-map)
 
 (define-minor-mode engine-mode
   "Minor mode for defining and querying search engines through Emacs.

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -50,9 +50,19 @@
 ;;; Code:
 (eval-when-compile (require 'cl))
 
-(defvar engine-mode-map (make-sparse-keymap))
+(defcustom engine/keybinding-prefix "C-x /"
+  "The default engine-mode keybindings prefix."
+  :group 'engine-mode
+  :type 'string)
+
 (define-prefix-command 'engine-mode-prefixed-map)
 (defvar engine-mode-prefixed-map)
+
+(defvar engine-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd engine/keybinding-prefix) engine-mode-prefixed-map)
+    map)
+  "Keymap for `engine-mode'.")
 
 ;;;###autoload
 (define-minor-mode engine-mode
@@ -69,13 +79,6 @@ For example, to use \"C-c s\" instead of the default \"C-x /\":
 (engine/set-keymap-prefix (kbd \"C-c s\"))"
   (define-key engine-mode-map (kbd engine/keybinding-prefix) nil)
   (define-key engine-mode-map prefix-key engine-mode-prefixed-map))
-
-(defcustom engine/keybinding-prefix "C-x /"
-  "The default engine-mode keybindings prefix."
-  :group 'engine-mode
-  :type 'string)
-
-(engine/set-keymap-prefix (kbd engine/keybinding-prefix))
 
 (defcustom engine/browser-function browse-url-browser-function
   "The default browser function used when opening a URL in an engine.

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -54,6 +54,7 @@
 (define-prefix-command 'engine-mode-prefixed-map)
 (defvar engine-mode-prefixed-map)
 
+;;;###autoload
 (define-minor-mode engine-mode
   "Minor mode for defining and querying search engines through Emacs.
 


### PR DESCRIPTION
* Define `engine-mode-prefixed-map` as just that - a prefix command
  - This allows the map to be autoloaded
* Autoload minor mode
* Add minor mode keymap docstring
* Appease byte-compiler
  - Avoid top-level side-effects (anything that isn't a definition)
  - Reorder definitions
  - Declare aforementioned prefix command as a variable

See also PR #30 by @syohex for another useful autoload.