### PR TITLE
Fix cl-lib usage and docstring syntax

### DIFF
--- a/engine-mode.el
+++ b/engine-mode.el
@@ -77,7 +77,7 @@
   "Bind the engine-mode keymap to a new prefix.
 For example, to use \"C-c s\" instead of the default \"C-x /\":
 
-(engine/set-keymap-prefix (kbd \"C-c s\"))"
+\(engine/set-keymap-prefix (kbd \"C-c s\"))"
   (define-key engine-mode-map (kbd engine/keybinding-prefix) nil)
   (define-key engine-mode-map prefix-key engine-mode-prefixed-map))
 
@@ -137,7 +137,7 @@ function that will be applied to the search term before it's
 substituted into `search-engine-url'. For example, if we wanted
 to always upcase our search terms, we might use:
 
-(defengine duckduckgo
+\(defengine duckduckgo
   \"https://duckduckgo.com/?q=%s\"
   :term-transformation-hook 'upcase)
 

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -49,7 +49,7 @@
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ;;; Code:
-(require 'cl-lib)
+(eval-when-compile (require 'cl-macs))
 
 (defcustom engine/keybinding-prefix "C-x /"
   "The default engine-mode keybindings prefix."
@@ -159,7 +159,7 @@ For example, to search Wikipedia, use:
 Hitting \"C-x / w\" will be bound to the newly-defined
 `engine/search-wikipedia' function."
 
-  (assert (symbolp engine-name))
+  (cl-assert (symbolp engine-name))
   `(prog1
      (defun ,(engine/function-name engine-name) (search-term)
        ,(or docstring (engine/docstring engine-name))


### PR DESCRIPTION
* Use `cl-assert` from `cl-macs.el`, not `assert` from unused `cl.el`.
* Avoid unnecessarily loading `cl-lib` at runtime.
* Escape bol open-parentheses in docstrings to prevent them from being treated as the start of a `defun`, as described in [`(info "(elisp) Function Documentation")`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Function-Documentation.html) and [`(info "(elisp) Documentation Tips")`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Documentation-Tips.html).