### PR TITLE
Doco: don't quote term-transformation-hook value

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For example, to UPCASE all of your DuckDuckGo searches:
 ```emacs
 (defengine duckduckgo
   "https://duckduckgo.com/?q=%s"
-  :term-transformation-hook 'upcase)
+  :term-transformation-hook upcase)
 ```
 
 Or, to ensure that all your queries are encoded as latin-1:

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -144,7 +144,7 @@ to always upcase our search terms, we might use:
 
 \(defengine duckduckgo
   \"https://duckduckgo.com/?q=%s\"
-  :term-transformation-hook 'upcase)
+  :term-transformation-hook upcase)
 
 In this case, searching for \"foobar\" will hit the url
 \"https://duckduckgo.com/?q=FOOBAR\".


### PR DESCRIPTION
Readme.md and the defengine docstring both falsely mandate quoting the function name (symbol) to be passed as value for the :term-transformation-hook key. This value is planted directly as a function call by the macro and thus must *not* be quoted. Try it: if you pass a quoted symbol as documented, the file containing the call will not byte-compile; if you pass it unquoted, the file will byte-compile.