### PR TITLE
Adding engine-mode to NonGNU ELPA

### DIFF
--- a/.elpaignore
+++ b/.elpaignore
@@ -1,0 +1,1 @@
+LICENSE.md

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 GNU GENERAL PUBLIC LICENSE
 Version 3, 29 June 2007
 
-Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
 Everyone is permitted to copy and distribute verbatim copies
 of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
 You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
 The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ override that on a case-by-case basis with the `:docstring` keyword argument:
 
 ```emacs
 (defengine ctan
-  "http://www.ctan.org/search/?x=1&PORTAL=on&phrase=%s"
+  "https://www.ctan.org/search/?x=1&PORTAL=on&phrase=%s"
   :docstring "Search the Comprehensive TeX Archive Network (ctan.org)")
 ```
 
@@ -156,7 +156,7 @@ to import them into Emacs.
 
 ```emacs
 (defengine amazon
-  "http://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Daps&field-keywords=%s")
+  "https://www.amazon.com/s/ref=nb_sb_noss?url=search-alias%3Daps&field-keywords=%s")
 
 (defengine duckduckgo
   "https://duckduckgo.com/?q=%s"
@@ -166,24 +166,24 @@ to import them into Emacs.
   "https://github.com/search?ref=simplesearch&q=%s")
 
 (defengine google
-  "http://www.google.com/search?ie=utf-8&oe=utf-8&q=%s"
+  "https://www.google.com/search?ie=utf-8&oe=utf-8&q=%s"
   :keybinding "g")
 
 (defengine google-images
-  "http://www.google.com/images?hl=en&source=hp&biw=1440&bih=795&gbv=2&aq=f&aqi=&aql=&oq=&q=%s")
+  "https://www.google.com/images?hl=en&source=hp&biw=1440&bih=795&gbv=2&aq=f&aqi=&aql=&oq=&q=%s")
 
 (defengine google-maps
-  "http://maps.google.com/maps?q=%s"
+  "https://maps.google.com/maps?q=%s"
   :docstring "Mappin' it up.")
 
 (defengine project-gutenberg
-  "http://www.gutenberg.org/ebooks/search/?query=%s")
+  "https://www.gutenberg.org/ebooks/search/?query=%s")
 
 (defengine qwant
   "https://www.qwant.com/?q=%s")
 
 (defengine rfcs
-  "http://pretty-rfc.herokuapp.com/search?q=%s")
+  "https://pretty-rfc.herokuapp.com/search?q=%s")
 
 (defengine stack-overflow
   "https://stackoverflow.com/search?q=%s")
@@ -192,7 +192,7 @@ to import them into Emacs.
   "https://twitter.com/search?q=%s")
 
 (defengine wikipedia
-  "http://www.wikipedia.org/search-redirect.php?language=en&go=Go&search=%s"
+  "https://www.wikipedia.org/search-redirect.php?language=en&go=Go&search=%s"
   :keybinding "w"
   :docstring "Searchin' the wikis.")
 
@@ -200,10 +200,10 @@ to import them into Emacs.
   "https://www.wikipedia.org/search-redirect.php?family=wiktionary&language=en&go=Go&search=%s")
 
 (defengine wolfram-alpha
-  "http://www.wolframalpha.com/input/?i=%s")
+  "https://www.wolframalpha.com/input/?i=%s")
 
 (defengine youtube
-  "http://www.youtube.com/results?aq=f&oq=&search_query=%s")
+  "https://www.youtube.com/results?aq=f&oq=&search_query=%s")
 ```
 
 [the talk @hrs gave at EmacsNYC]: https://www.youtube.com/watch?v=MBhJBMYfWUo

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -1,4 +1,4 @@
-;;; engine-mode.el --- Define and query search engines from within Emacs.
+;;; engine-mode.el --- Define and query search engines from within Emacs
 
 ;; Author: Harry R. Schwartz <hello@harryrschwartz.com>
 ;; Version: 2.2.0
@@ -6,6 +6,19 @@
 ;; Package-Requires: ((cl-lib "0.5"))
 
 ;; This file is NOT part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 
@@ -33,24 +46,13 @@
 ;; `C-x / d' is now bound to the new function
 ;; engine/search-duckduckgo'! Nifty.
 
-;;; License:
-
-;; This program is free software: you can redistribute it and/or modify
-;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation, either version 3 of the License, or
-;; (at your option) any later version.
-
-;; This program is distributed in the hope that it will be useful,
-;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;; GNU General Public License for more details.
-
-;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 ;;; Code:
-(eval-when-compile (require 'cl-macs))
+(eval-when-compile (require 'cl-lib))
 (require 'format-spec)
+
+(defgroup engine-mode nil
+  "Define search engines, bind them to keybindings, and query them."
+  :group 'external)
 
 (defcustom engine/keybinding-prefix "C-x /"
   "The default engine-mode keybindings prefix."

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -159,7 +159,7 @@ Keybindings are in the `engine-mode-map', so they're prefixed.
 For example, to search Wikipedia, use:
 
   (defengine wikipedia
-    \"http://www.wikipedia.org/search-redirect.php?language=en&go=Go&search=%s\"
+    \"https://www.wikipedia.org/search-redirect.php?language=en&go=Go&search=%s\"
     :keybinding \"w\"
     :docstring \"Search Wikipedia!\")
 

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -1,7 +1,7 @@
 ;;; engine-mode.el --- Define and query search engines from within Emacs
 
 ;; Author: Harry R. Schwartz <hello@harryrschwartz.com>
-;; Version: 2.2.0
+;; Version: 2.2.1
 ;; URL: https://github.com/hrs/engine-mode
 ;; Package-Requires: ((cl-lib "0.5"))
 

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -54,8 +54,8 @@
 
 (defcustom engine/keybinding-prefix "C-x /"
   "The default engine-mode keybindings prefix."
-  :group 'engine-mode
-  :type 'string)
+  :type '(choice (string :tag "Key")
+                 (const :tag "No keybinding" nil)))
 
 (define-prefix-command 'engine-mode-prefixed-map)
 (defvar engine-mode-prefixed-map)
@@ -79,7 +79,8 @@
 For example, to use \"C-c s\" instead of the default \"C-x /\":
 
 \(engine/set-keymap-prefix (kbd \"C-c s\"))"
-  (define-key engine-mode-map (kbd engine/keybinding-prefix) nil)
+  (when engine/keybinding-prefix
+    (define-key engine-mode-map (kbd engine/keybinding-prefix) nil))
   (define-key engine-mode-map prefix-key engine-mode-prefixed-map))
 
 (defcustom engine/browser-function browse-url-browser-function


### PR DESCRIPTION
Hi!

I am looking into adding this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that is enabled by default in Emacs 28.1 or later. This means that users will be able to install this package without additional configuration.

The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release is made automatically when you bump the `";; Version: NNN"` commentary header in this repository, as I do in the below commit. NonGNU ELPA does not look at any "git tag". In the future, you can bump the package version in that header when you want to release a new version.

The rules for accepting a package into NonGNU ELPA are here, for your reference:
https://git.savannah.gnu.org/cgit/emacs/nongnu.git/tree/README.org#n118

As far as I can tell, this package already follows the rules, but note that NonGNU ELPA does not distribute any package that recommends non-free software.

Please let me know if you have any questions. See below also some additional fixes I did while looking into this; all of them should be applicable whether or not this package is added to NonGNU ELPA.

Thanks!