### PR TITLE
Add Melpazoid workflow and fix some linting errors

### DIFF
--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -1,0 +1,37 @@
+# melpazoid <https://github.com/riscy/melpazoid> build checks.
+
+name: Melpazoid
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Install Emacs
+      uses: purcell/setup-emacs@master
+      with:
+        version: snapshot
+
+    - name: Install Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.9
+
+    - name: Install Melpazoid
+      run: |
+        python -m pip install --upgrade pip
+        git clone https://github.com/riscy/melpazoid.git ~/melpazoid
+        pip install ~/melpazoid
+
+    - name: Run
+      env:
+        LOCAL_REPO: ${{ github.workspace }}
+        RECIPE: (engine-mode :repo "hrs/engine-mode" :fetcher github)
+      run: echo $GITHUB_REF && make -C ~/melpazoid
+      continue-on-error: true

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -1,7 +1,7 @@
 ;;; engine-mode.el --- Define and query search engines
 
 ;; Author: Harry R. Schwartz <hello@harryrschwartz.com>
-;; Version: 2.2.3
+;; Version: 2.2.4
 ;; URL: https://github.com/hrs/engine-mode
 ;; Package-Requires: ((cl-lib "0.5"))
 

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -49,12 +49,13 @@
 (eval-when-compile (require 'cl-lib))
 (require 'format-spec)
 
-(defgroup engine-mode nil
+(defgroup engine nil
   "Define search engines, bind them to keybindings, and query them."
   :group 'external)
 
 (defcustom engine/keybinding-prefix "C-x /"
   "The default `engine-mode' keybindings prefix."
+  :group 'engine
   :type '(choice (string :tag "Key")
                  (const :tag "No keybinding" nil)))
 
@@ -87,7 +88,7 @@ For example, to use \"C-c s\" instead of the default \"C-x /\":
 (defcustom engine/browser-function browse-url-browser-function
   "The default browser function used when opening a URL in an engine.
 Defaults to `browse-url-browser-function'."
-  :group 'engine-mode
+  :group 'engine
   :type 'symbol)
 
 (defun engine--search-prompt (engine-name default-word)


### PR DESCRIPTION
This adds linting through the [Melpazoid](https://github.com/riscy/melpazoid) GitHub action, which exists to lint packages in MELPA.

However, this configuration won't fail the build, even if linting fails. `engine-mode` has been around for a while, and renaming some functions might take some time, so `package-lint` is likely to keep failing for the foreseeable future. I appreciate melpazoid's advice, and I want to keep it around with the eventual goal of enabling it "for real," but I'm not ready to implement all its suggestions yet, so this ensures that it doesn't fail a build even if its checks fail.

This PR also incorporates some of its suggestions. Notably, it:

- Prefixes "private" functions with `engine--` (instead of `engine/`), but doesn't change "public" functions or `defcustom` variables.
- Renames the customization group: `engine-mode` → `engine`
- Fixes some `checkdoc` errors: shorten longer lines, use ALL-CAPS for variables in docstrings
- Condenses package summary to remove explicit reference to Emacs (since *of course* this is for Emacs)
- Modifies text wrap width in commentary section

I don't think anything in there should break anyone's config. The renamed functions were essentially private already, and a cursory search through GitHub didn't turn up any explicit uses of them.

From an abundance of caution, though, this is a new point release, `2.2.4`, so people can revert more easily if they need to.

Closes #61.