### PR TITLE
Backfill tests for most simple functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         emacs_version:
-          - 24.3
           - 24.4
           - 24.5
           - 25.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,9 @@ jobs:
       with:
         version: ${{ matrix.emacs_version }}
 
+    - name: Install buttercup package
+      run: emacs --quick --batch -f package-initialize --eval "(add-to-list 'package-archives '(\"nongnu\" . \"https://elpa.nongnu.org/nongnu/\") t)" --eval "(package-refresh-contents)" --eval "(package-install 'buttercup)"
+
     - name: Run tests
       if: matrix.allow_failure != true
       run: 'make && make test'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .PHONY: test
 test: engine-mode.el engine-mode-test.el
 	emacs --quick --batch \
-	-l ert \
-	-l engine-mode-test.el \
-	--eval "(setq ert-batch-backtrace-right-margin 10000)" \
-	-f ert-run-tests-batch-and-exit
+	-f package-initialize \
+	-L . \
+	-f buttercup-run-discover

--- a/engine-mode-test.el
+++ b/engine-mode-test.el
@@ -8,16 +8,84 @@
 
 ;;; Code:
 
+(require 'buttercup)
 (load-file "engine-mode.el")
 
-(ert-deftest engine--function-name ()
-  (should (equal (engine--function-name 'wikipedia)
-                 'engine/search-wikipedia))
-  (should (equal (engine--function-name 'GitHub)
-                 'engine/search-github)))
+(describe "engine--search-prompt"
+          (it "includes the default term in the prompt"
+              (expect (engine--search-prompt "wikipedia" "the-thing-at-point")
+                      :to-equal
+                      "Search Wikipedia (the-thing-at-point): "))
 
-(ert-deftest engine--docstring ()
-  (should (equal (engine--docstring 'my-engine)
-                 "Search My-Engine for the selected text.\nPrompt for input if none is selected.")))
+          (it "doesn't include the default term if it's empty"
+              (expect (engine--search-prompt "wikipedia" "")
+                      :to-equal
+                      "Search Wikipedia: ")))
+
+(describe "engine--prompted-search-term"
+          (it "reads a string from the user"
+              (spy-on 'read-string :and-return-value "spy term")
+              (spy-on 'thing-at-point :and-return-value nil)
+
+              (expect (engine--prompted-search-term "wikipedia")
+                      :to-equal "spy term")
+              (expect 'read-string :to-have-been-called-with
+                      (engine--search-prompt "wikipedia" "") nil nil ""))
+
+          (it "defaults the term to the thing-at-point, if there is one"
+              (spy-on 'read-string :and-return-value "spy term")
+              (with-temp-buffer
+                (insert "foo")
+                (goto-char 1)
+                (expect (engine--prompted-search-term "wikipedia")
+                        :to-equal "spy term"))
+
+              (expect 'read-string :to-have-been-called-with
+                      (engine--search-prompt "wikipedia" "foo") nil nil "foo")))
+
+(describe "engine--get-query"
+          (it "returns a region, if one's active"
+              (expect (with-temp-buffer
+                        (transient-mark-mode)
+
+                        (insert "lorem ipsum")
+                        (goto-char 3)
+                        (push-mark-command (point))
+                        (goto-char 10)
+
+                        (engine--get-query "wikipedia"))
+                      :to-equal "rem ips"))
+
+          (it "delegates to engine--prompted-search-term if there's no active region"
+              (spy-on 'read-string :and-return-value "spy term")
+              (expect (engine--get-query "wikipedia")
+                      :to-equal
+                      (engine--prompted-search-term "wikipedia"))))
+
+(describe "engine--execute-search"
+          (it "encodes the search term, interpolates it into the URL, and browses it"
+              (expect (engine--execute-search
+                       "https://www.wikipedia.org/search-redirect.php?search=%s"
+                       (lambda (url &rest _) (cons 'browsed url))
+                       "foo bar")
+                      :to-equal
+                      '(browsed . "https://www.wikipedia.org/search-redirect.php?search=foo%20bar"))))
+
+(describe "engine--function-name"
+          (it "returns the function name created by the engine with this name"
+              (expect (engine--function-name 'wikipedia)
+                      :to-equal
+                      'engine/search-wikipedia))
+
+          (it "downcases the engine name"
+              (expect (engine--function-name 'GitHub)
+                      :to-equal
+                      'engine/search-github)))
+
+(describe "engine--docstring"
+  (it "returns a default docstring with the engine name interpolated"
+      (expect (engine--docstring 'my-engine)
+              :to-equal
+              "Search My-Engine for the selected text.\nPrompt for input if none is selected.")))
 
 ;;; engine-mode-test.el ends here

--- a/engine-mode.el
+++ b/engine-mode.el
@@ -3,7 +3,7 @@
 ;; Author: Harry R. Schwartz <hello@harryrschwartz.com>
 ;; Version: 2.2.4
 ;; URL: https://github.com/hrs/engine-mode
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.4"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
This also switches the testing framework to use [buttercup](https://github.com/jorgenschaefer/emacs-buttercup/), which provides some convenient tools for spying on functions.

This addresses some of the issues in #63, covering "simple unit tests" and "getting the right search term."