### PR TITLE
Install buttercup through make task, not CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,13 +38,10 @@ jobs:
       with:
         version: ${{ matrix.emacs_version }}
 
-    - name: Install buttercup package
-      run: emacs --quick --batch -f package-initialize --eval "(add-to-list 'package-archives '(\"nongnu\" . \"https://elpa.nongnu.org/nongnu/\") t)" --eval "(package-refresh-contents)" --eval "(package-install 'buttercup)"
-
     - name: Run tests
       if: matrix.allow_failure != true
-      run: 'make && make test'
+      run: 'make test'
 
     - name: Run tests (allow failure)
       if: matrix.allow_failure == true
-      run: 'make && make test || true'
+      run: 'make test || true'

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,7 @@
 test: engine-mode.el engine-mode-test.el
 	emacs --quick --batch \
 	-f package-initialize \
+  --eval "(add-to-list 'package-archives '(\"nongnu\" . \"https://elpa.nongnu.org/nongnu/\") t)" \
+  --eval "(when (not (package-installed-p 'buttercup)) (package-refresh-contents) (package-install 'buttercup))" \
 	-L . \
 	-f buttercup-run-discover


### PR DESCRIPTION
This way running `make` locally will ensure that buttercup's installed, rather than only installing it as part of the CI process.