### PR TITLE
Fix lexical binding annotation for buttercup

### DIFF
--- a/engine-mode-test.el
+++ b/engine-mode-test.el
@@ -1,6 +1,4 @@
-;;; engine-mode-test.el --- tests for engine-mode.el
-
-;; -*- lexical-binding: t; -*-
+;;; engine-mode-test.el --- tests for engine-mode.el -*- lexical-binding: t; -*-
 
 ;;; Commentary:
 


### PR DESCRIPTION
A [recent build failed](https://github.com/hrs/engine-mode/actions/runs/10732652907) because the `buttercup` testing library now requires its files to use lexical binding, and I'd had the variable set on the wrong line. Whoops! This addresses that.